### PR TITLE
Fix "Array values in parameter to Gem.path= are deprecated" warning

### DIFF
--- a/bin/spring
+++ b/bin/spring
@@ -8,7 +8,7 @@ unless defined?(Spring)
   require 'bundler'
 
   if (match = Bundler.default_lockfile.read.match(/^GEM$.*?^    (?:  )*spring \((.*?)\)$.*?^$/m))
-    Gem.paths = { 'GEM_PATH' => [Bundler.bundle_path.to_s, *Gem.path].uniq }
+    Gem.paths = { 'GEM_PATH' => [Bundler.bundle_path.to_s, *Gem.path].uniq.join(File::PATH_SEPARATOR) }
     gem 'spring', match[1]
     require 'spring/binstub'
   end


### PR DESCRIPTION
Fix "Array values in parameter to Gem.path= are deprecated" warning when run ```rails server``` command